### PR TITLE
Update Helm chart default values for security context to comply with restricted PodSecurity standards

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,16 +19,19 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsNonRoot: true
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   webhook:


### PR DESCRIPTION
# Changes

This pull request updates the default values of the Helm chart to setup the Shipwright Triggers deployment to satisfy the requirements of the restricted PodSecurity requirements. This is necessary to run it in the shipwright-build namespace which enforeces this since [Setup security context of controller deployment, enforce restricted PodSecurity in namespace #1342](https://github.com/shipwright-io/build/pull/1342).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The shipwright-triggers deployment now satisfies the restricted PodSecurity standard
```