### PR TITLE
Use Go `1.22` in GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -5,7 +5,7 @@ inputs:
   go-version:
     description: "The Go version to download (if necessary) and use. Supports semver spec and ranges. Be sure to enclose this option in single quotation marks."
     required: false
-    default: "1.21"
+    default: "1.22.x"
 runs:
   using: composite
   steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       release:
         description: 'Desired tag'
-        required: true 
+        required: true
       tags:
         description: 'Previous tag'
         required: true
@@ -51,7 +51,7 @@ jobs:
         prerelease: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
     - name: Generate and upload release.yaml
       env:
         REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -67,4 +67,3 @@ jobs:
             -a sha=${{ github.sha }} \
             -a run_id=${{ github.run_id }} \
             -a run_attempt=${{ github.run_attempt }}
-  

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21.x'
+          go-version: 1.22.x
           check-latest: true
 
       - name: Run gosec

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
         with:
-          go-version: '1.21.x'
+          go-version: 1.22.x
       - name: test-unit
         run: make test-unit
   integration:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
         with:
-          go-version: '1.21.x'
+          go-version: 1.22.x
       - name: test-integration
         run: make test-integration
 


### PR DESCRIPTION
# Changes

Use latest Go version `1.22` for any Go related GitHub Action.

/kind dependency-change

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
