### PR TITLE
feat: Add git-ref to Release Pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,12 @@ on:
       tags:
         description: 'Previous tag'
         required: true
+      git-ref:
+        description: 'Git reference to check out. Use an appropriate release-v* branch name, tag, or commit SHA.'
+        required: true
+        default: 'main'
 jobs:
   release:
-    if: ${{ github.repository == 'shipwright-io/build' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # To be able to get OIDC ID token to sign images.
@@ -25,6 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.git-ref }}
     - uses: ./.github/actions/setup
     - uses: sigstore/cosign-installer@v3
     - uses: azure/setup-helm@v3.5
@@ -44,7 +49,7 @@ jobs:
       id: draft_release
       uses: actions/create-release@v1
       with:
-        release_name: "Shipwright Build release ${{ github.event.inputs.release }}"
+        release_name: "Shipwright Triggers release ${{ github.event.inputs.release }}"
         tag_name: ${{ github.event.inputs.release }}
         body_path: Changes.md
         draft: true


### PR DESCRIPTION
# Changes

Update the release pipeline so it can accept a git reference, so that we can maintain release branches. See [SHIP-0038](https://github.com/shipwright-io/community/blob/main/ships/0038-release-branching-backports.md).

Fixes #139 

/kind feature

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Add git reference as input to release pipeline workflow.
```
