### PR TITLE
Bump ko-build/setup-ko from v0.7 to v0.9

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -14,7 +14,7 @@ runs:
         go-version: ${{ inputs.go-version }}
         cache: true
         check-latest: true
-    - uses: ko-build/setup-ko@v0.7
+    - uses: ko-build/setup-ko@v0.9
     - name: install-goml
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- Updates `ko-build/setup-ko` GitHub Action from v0.7 to v0.9 in `.github/actions/setup/action.yaml`

Made with [Cursor](https://cursor.com)