### PR TITLE
Pin envtest versions to go.mod dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,9 @@ KO_OPTS ?= --base-import-paths --tags=${IMAGE_TAG}
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
 CONTROLLER_GEN ?= $(LOCAL_BIN)/controller-gen
 
-# envtest version and full path to the executable
-ENVTEST_K8S_VERSION ?= 1.34
+# envtest k8s and setup-envtest versions, derived from go.mod dependencies
+ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
+ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 ENVTEST ?= $(LOCAL_BIN)/setup-envtest
 
 # chart base directory and path to the "templates" folder
@@ -119,12 +120,12 @@ test-unit: CGO_ENABLED=1
 test-unit:
 	go test $(GOFLAGS_TEST) $(ARGS) ./pkg/... ./controllers/...
 
-# installs latest envtest-setup
+# installs envtest-setup
 .PHONY: envtest
 envtest: GOBIN=$(LOCAL_BIN)
 envtest: $(ENVTEST)
 $(ENVTEST):
-	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 # run integration tests, with optional arguments
 .PHONY: test-integration


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here. Ideally you can get that description straight from
your descriptive commit message(s)! -->
Pin `setup-envtest` and `ENVTEST_K8S_VERSION` to versions derived from `go.mod` dependencies instead of using `@latest` or hardcoded values. 

This follows the pattern used by Kubebuilder-scaffolded projects to ensure version consistency between controller-runtime and its setup-envtest tool. See https://book.kubebuilder.io/reference/envtest

# Related Issue

<!-- Link the GitHub issue this PR addresses. Use "Fixes" to auto-close the issue on merge,
or "Related to" if the issue needs additional work. -->

Closes #187 

# Type of PR

<!-- Replace with one of the following `/kind` commands so Prow applies the label:

/kind bug
/kind feature
/kind cleanup
/kind documentation

See the [kind command docs](https://prow.k8s.io/command-help#kind) for more details. -->

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!-- Describe any user-facing changes here, or mark as NONE.

Examples of user-facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

If this PR requires additional action from users switching to the new release,
include the string "action required" (case insensitive) in the release note.

If there are no user-facing changes, write NONE below. -->

```release-note
NONE
```
